### PR TITLE
Add Slick support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,12 @@ resolvers += "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"
       
 scalaVersion := "2.12.2"
 
-libraryDependencies ++= Seq( jdbc , ehcache , ws , specs2 % Test , guice )
+libraryDependencies += guice
+libraryDependencies ++= Seq( ehcache , ws )
+libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.2" % Test
+libraryDependencies += "com.typesafe.play" %% "play-slick" % "4.0.0"
+libraryDependencies += "com.typesafe.play" %% "play-slick-evolutions" % "4.0.0"
+libraryDependencies += "org.postgresql" % "postgresql" % "42.1.4"
+libraryDependencies += specs2 % Test
 
 unmanagedResourceDirectories in Test <+=  baseDirectory ( _ /"target/web/public/test" )  
-
-      

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,6 @@ resolvers += "Akka Snapshot Repository" at "http://repo.akka.io/snapshots/"
 scalaVersion := "2.12.2"
 
 libraryDependencies += guice
-libraryDependencies ++= Seq( ehcache , ws )
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.2" % Test
 libraryDependencies += "com.typesafe.play" %% "play-slick" % "4.0.0"
 libraryDependencies += "com.typesafe.play" %% "play-slick-evolutions" % "4.0.0"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -373,3 +373,12 @@ db {
   # https://www.playframework.com/documentation/latest/Highlights25#Logging-SQL-statements
   #default.logSql=true
 }
+
+
+slick.dbs.default.profile="slick.jdbc.PostgresProfile$"
+slick.dbs.default.db.dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+slick.dbs.default.db.properties.driver = "org.postgresql.Driver"
+slick.dbs.default.db.properties.url="jdbc:postgresql://localhost/announcify_db"  //?currentSchema=postgres&user=postgres&password=postgres"
+slick.dbs.default.db.properties.user = "announcify"   # tmp hardcoded value for hard times, will change
+slick.dbs.default.db.properties.password = "announcify"
+slick.dbs.default.db.connectionTestQuery = "SELECT 1" # workaround for bug in the postgres driver error: "Failed to execute isValid()"


### PR DESCRIPTION
For now I hard coded database user, password and name. It requires local instance of PostgreSQL running with matching user and db. More elegant solutions I see are:
* Separate config file not included in repository
* Storing those values in environmental variables

For this stage of development it should do though.